### PR TITLE
ci: Don't provide additional history when generating release notes

### DIFF
--- a/docs/privacy/index.markdown
+++ b/docs/privacy/index.markdown
@@ -1,5 +1,5 @@
 ---
-title: Privacy Policy
+title: Privacy
 ---
 
 # Privacy Policy

--- a/scripts/update-release-notes.sh
+++ b/scripts/update-release-notes.sh
@@ -30,11 +30,10 @@ SCRIPTS_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd 
 ROOT_DIRECTORY="${SCRIPTS_DIRECTORY}/.."
 RELEASE_NOTES_TEMPLATE_PATH="${SCRIPTS_DIRECTORY}/release-notes.markdown"
 RELEASE_NOTES_PATH="${ROOT_DIRECTORY}/docs/releases/index.markdown"
-HISTORY_PATH="${ROOT_DIRECTORY}/history.yaml"
 
 source "${SCRIPTS_DIRECTORY}/environment.sh"
 
 
 cd "$ROOT_DIRECTORY"
 
-changes notes --all --released --history "$HISTORY_PATH" --template "$RELEASE_NOTES_TEMPLATE_PATH" > "$RELEASE_NOTES_PATH"
+changes notes --all --released --template "$RELEASE_NOTES_TEMPLATE_PATH" > "$RELEASE_NOTES_PATH"


### PR DESCRIPTION
This includes a drive-by fix to update the title of the privacy policy page.