### PR TITLE
fix: Show selected symbol in the symbol picker

### DIFF
--- a/Symbolic.xcodeproj/project.pbxproj
+++ b/Symbolic.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		D84868EC296AE437009FDF32 /* IconSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84868EB296AE437009FDF32 /* IconSet.swift */; };
 		D84868EE296AE486009FDF32 /* IconDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84868ED296AE486009FDF32 /* IconDefinition.swift */; };
 		D84868F0296AE616009FDF32 /* IconSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84868EF296AE616009FDF32 /* IconSection.swift */; };
+		D857297C296C176C0037E58F /* SymbolPickerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D857297B296C176C0037E58F /* SymbolPickerCell.swift */; };
 		D864A23A2965A2D1008A4261 /* Interact in Frameworks */ = {isa = PBXBuildFile; productRef = D864A2392965A2D1008A4261 /* Interact */; };
 		D864A23C2965E239008A4261 /* MacIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864A23B2965E239008A4261 /* MacIconView.swift */; };
 		D86B0ECF291BEF7400352367 /* IconDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86B0ECE291BEF7400352367 /* IconDocument.swift */; };
@@ -90,6 +91,7 @@
 		D84868EB296AE437009FDF32 /* IconSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconSet.swift; sourceTree = "<group>"; };
 		D84868ED296AE486009FDF32 /* IconDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconDefinition.swift; sourceTree = "<group>"; };
 		D84868EF296AE616009FDF32 /* IconSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconSection.swift; sourceTree = "<group>"; };
+		D857297B296C176C0037E58F /* SymbolPickerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolPickerCell.swift; sourceTree = "<group>"; };
 		D864A2382965999C008A4261 /* interact */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = interact; sourceTree = "<group>"; };
 		D864A23B2965E239008A4261 /* MacIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacIconView.swift; sourceTree = "<group>"; };
 		D86B0ECE291BEF7400352367 /* IconDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconDocument.swift; sourceTree = "<group>"; };
@@ -175,13 +177,14 @@
 				D8CD4A7F28AC35C300D57F34 /* ContentView.swift */,
 				D84868E7296ACC58009FDF32 /* Header.swift */,
 				D821B9EB28ACDC2600504AA4 /* IconCorners.swift */,
+				D826B5CC296B312300693D27 /* IconPreview.swift */,
 				D84868E9296ACC8B009FDF32 /* IconSetView.swift */,
 				D821B9E328ACDBA800504AA4 /* IconView.swift */,
 				D864A23B2965E239008A4261 /* MacIconView.swift */,
 				D821B9ED28ACDC6F00504AA4 /* SymbolPicker.swift */,
+				D857297B296C176C0037E58F /* SymbolPickerCell.swift */,
 				D83970E628B132C700282EE8 /* UnityScaleWindow.swift */,
 				D826B5C3296B054000693D27 /* WatchGridView.swift */,
-				D826B5CC296B312300693D27 /* IconPreview.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -453,6 +456,7 @@
 				D821B9EC28ACDC2600504AA4 /* IconCorners.swift in Sources */,
 				D821B9EE28ACDC6F00504AA4 /* SymbolPicker.swift in Sources */,
 				D8B61308293BB81100F29E0C /* AboutCommands.swift in Sources */,
+				D857297C296C176C0037E58F /* SymbolPickerCell.swift in Sources */,
 				D84868F0296AE616009FDF32 /* IconSection.swift in Sources */,
 				D8F6317428AC7D7A00DFEED0 /* SFSymbols.swift in Sources */,
 				D83970E928B1340900282EE8 /* DeviceType.swift in Sources */,

--- a/Symbolic/Views/SymbolPicker.swift
+++ b/Symbolic/Views/SymbolPicker.swift
@@ -22,6 +22,12 @@ import SwiftUI
 
 struct SymbolPicker: View {
 
+    struct LayoutMetrics {
+        static let itemSize = 38.0
+        static let interItemSpacing = 6.0
+        static let height = 400.0
+    }
+
     var title: String
     var systemImage: Binding<String>
     @State var initialImage: String
@@ -34,11 +40,11 @@ struct SymbolPicker: View {
         _initialImage = State(initialValue: systemImage.wrappedValue)
     }
 
-    let columns = [GridItem(.flexible(minimum: 38), spacing: 16.0),
-                   GridItem(.flexible(minimum: 38), spacing: 16.0),
-                   GridItem(.flexible(minimum: 38), spacing: 16.0),
-                   GridItem(.flexible(minimum: 38), spacing: 16.0),
-                   GridItem(.flexible(minimum: 38), spacing: 16.0)]
+    let columns = [GridItem(.flexible(minimum: LayoutMetrics.itemSize), spacing: LayoutMetrics.interItemSpacing),
+                   GridItem(.flexible(minimum: LayoutMetrics.itemSize), spacing: LayoutMetrics.interItemSpacing),
+                   GridItem(.flexible(minimum: LayoutMetrics.itemSize), spacing: LayoutMetrics.interItemSpacing),
+                   GridItem(.flexible(minimum: LayoutMetrics.itemSize), spacing: LayoutMetrics.interItemSpacing),
+                   GridItem(.flexible(minimum: LayoutMetrics.itemSize), spacing: LayoutMetrics.interItemSpacing)]
 
     var body: some View {
         LabeledContent("Symbol") {
@@ -54,23 +60,18 @@ struct SymbolPicker: View {
             .controlSize(.large)
             .popover(isPresented: $isPresented) {
                 ScrollView {
-                    LazyVGrid(columns: columns, spacing: 16.0) {
+                    LazyVGrid(columns: columns, spacing: LayoutMetrics.interItemSpacing) {
                         ForEach(model.filteredSymbolNames) { symbol in
-                            HStack {
-                                Image(systemName: symbol)
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .controlSize(.regular)
-                                    .onTapGesture {
-                                        isPresented = false
-                                        systemImage.wrappedValue = symbol
-                                    }
-                            }
-                            .aspectRatio(1.0, contentMode: .fit)
+                            SymbolPickerCell(systemName: symbol, isHighlighted: systemImage.wrappedValue == symbol)
+                                .onTapGesture {
+                                    isPresented = false
+                                    systemImage.wrappedValue = symbol
+                                }
                         }
                     }
-                    .padding()
+                    .padding([.leading, .trailing, .bottom])
                 }
+                .background(Color(nsColor: NSColor.controlBackgroundColor))
                 .safeAreaInset(edge: .top) {
                     TextField(text: $model.filter, prompt: Text("Search")) {
                         EmptyView()
@@ -78,9 +79,9 @@ struct SymbolPicker: View {
                     .multilineTextAlignment(.leading)
                     .textFieldStyle(.roundedBorder)
                     .padding()
-                    .background(.regularMaterial)
+                    .background(Color(nsColor: NSColor.controlBackgroundColor))
                 }
-                .frame(height: 400)
+                .frame(height: LayoutMetrics.height)
             }
         }
         .onAppear {

--- a/Symbolic/Views/SymbolPickerCell.swift
+++ b/Symbolic/Views/SymbolPickerCell.swift
@@ -1,0 +1,55 @@
+// Copyright (c) 2022-2023 InSeven Limited
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import SwiftUI
+
+struct SymbolPickerCell: View {
+
+    struct LayoutMetrics {
+        static let cornerRadius = 6.0
+        static let padding = 6.0
+    }
+
+    let systemName: String
+    let isHighlighted: Bool
+
+    @State var isHovering: Bool = false
+
+    var body: some View {
+        ZStack {
+            if isHighlighted || isHovering {
+                RoundedRectangle(cornerRadius: LayoutMetrics.cornerRadius)
+                    .fill(Color(nsColor: NSColor.unemphasizedSelectedContentBackgroundColor))
+            }
+            Image(systemName: systemName)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .controlSize(.regular)
+                .foregroundColor(.primary)
+                .padding(LayoutMetrics.padding)
+        }
+        .aspectRatio(1.0, contentMode: .fit)
+        .onHover { isHovering in
+            self.isHovering = isHovering
+        }
+
+    }
+
+}

--- a/Symbolic/Views/SymbolPickerCell.swift
+++ b/Symbolic/Views/SymbolPickerCell.swift
@@ -34,10 +34,8 @@ struct SymbolPickerCell: View {
 
     var body: some View {
         ZStack {
-            if isHighlighted || isHovering {
-                RoundedRectangle(cornerRadius: LayoutMetrics.cornerRadius)
-                    .fill(Color(nsColor: NSColor.unemphasizedSelectedContentBackgroundColor))
-            }
+            RoundedRectangle(cornerRadius: LayoutMetrics.cornerRadius)
+                .fill(isHighlighted || isHovering ? Color(nsColor: NSColor.unemphasizedSelectedContentBackgroundColor) : .clear)
             Image(systemName: systemName)
                 .resizable()
                 .aspectRatio(contentMode: .fit)


### PR DESCRIPTION
This change includes a drive-by fix to how a highlight when hovering over symbols in the picker.