### PR TITLE
fix: Improved default window size

### DIFF
--- a/Symbolic/SymbolicApp.swift
+++ b/Symbolic/SymbolicApp.swift
@@ -33,6 +33,7 @@ struct SymbolicApp: App {
             ContentView()
                 .environmentObject(applicationModel)
         }
+        .defaultSize(width: 800, height: 780)
         .commands {
             AboutCommands(applicationModel: applicationModel)
             ExportCommands(applicationModel: applicationModel)


### PR DESCRIPTION
Sets the default window size to show multiple icon previews and ensure the top of one is visible to encourage scrolling.

<img width="1293" alt="Screenshot 2023-01-09 at 10 19 43" src="https://user-images.githubusercontent.com/220887/211286504-7e4f4725-c95c-469d-8f4d-3dffdacb4e5e.png">
