### PR TITLE
fix: Center the icon previews in the main scroll view

### DIFF
--- a/Symbolic/Layouts/CenteredFlowLayout.swift
+++ b/Symbolic/Layouts/CenteredFlowLayout.swift
@@ -80,14 +80,11 @@ struct CenteredFlowLayout: Layout {
     }
 
     func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
-        guard let width = proposal.width else {
-            return
-        }
         var posY = bounds.minY
         for row in subviews.rows(proposal: proposal) {
             let rowWidth = row.map({ $1.width }).reduce(0.0, +)
             let rowHeight = row.map({ $1.height }).reduce(0.0, max)
-            var posX = ((width - rowWidth) / 2)
+            var posX = ((bounds.width - rowWidth) / 2) + bounds.minX
             for (subview, size) in row {
                 subview.place(at: CGPoint(x: posX, y: posY + rowHeight),
                               anchor: .bottomLeading,

--- a/Symbolic/SymbolicApp.swift
+++ b/Symbolic/SymbolicApp.swift
@@ -33,7 +33,7 @@ struct SymbolicApp: App {
             ContentView()
                 .environmentObject(applicationModel)
         }
-        .defaultSize(width: 800, height: 780)
+        .defaultSize(width: 1250, height: 780)
         .commands {
             AboutCommands(applicationModel: applicationModel)
             ExportCommands(applicationModel: applicationModel)


### PR DESCRIPTION
This change also includes a drive-by fix to tweak the initial window size to present more previews.