### PR TITLE
fix: Show the symbol variant name in the symbol picker tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Symbolic follows the version numbering, build and signing conventions for InSeve
 
 Symbolic includes [Google Material Icons](https://fonts.google.com/icons) which are licensed under the [Apache License](https://www.apache.org/licenses/LICENSE-2.0.html).
 
-Instead of using a submodule, the have been imported into the project using `scripts/import-material-design-icons.py` as the Material Icons repository is about 16GB and including this would significantly impact checkout and build times.
+Instead of using a submodule, they have been imported into the project using `scripts/import-material-design-icons.py` as the Material Icons repository is about 16GB and including this would significantly impact checkout and build times.
 
 Update the icons as follows:
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ Icon designer
 
 Symbolic follows the version numbering, build and signing conventions for InSeven Limited apps. Further details can be found [here](https://github.com/inseven/build-documentation).
 
+## Symbols
+
+### Material Icons
+
+Symbolic includes [Google Material Icons](https://fonts.google.com/icons) which are licensed under the [Apache License](https://www.apache.org/licenses/LICENSE-2.0.html).
+
+Instead of using a submodule, the have been imported into the project using `scripts/import-material-design-icons.py` as the Material Icons repository is about 16GB and including this would significantly impact checkout and build times.
+
+Update the icons as follows:
+
+```bash
+scripts/import-material-design-icons.py ~/Projects/material-design-icons	
+```
+
 ## Licensing
 
 Symbolic is licensed under the MIT License (see [LICENSE](LICENSE)).

--- a/Symbolic/Models/Manifest.swift
+++ b/Symbolic/Models/Manifest.swift
@@ -22,6 +22,10 @@ import Foundation
 
 struct Manifest: Codable {
 
+    struct VariantDefinition: Codable {
+        let name: String
+    }
+
     struct Variant: Codable {
         let path: String
     }
@@ -31,11 +35,12 @@ struct Manifest: Codable {
         let name: String
         let variants: [String: Variant]
     }
-
+    
     let id: String
     let name: String
     let author: String
     let license: String
+    let variants: [String: VariantDefinition]
     let symbols: [Symbol]
 
 }

--- a/Symbolic/Models/Symbol.swift
+++ b/Symbolic/Models/Symbol.swift
@@ -26,18 +26,30 @@ struct Symbol: Identifiable {
         return reference.id
     }
 
-    var variant: String? {
-        return reference.variant
-    }
-
     enum Format {
         case svg
         case symbol
     }
 
     let reference: SymbolReference
+    let variant: Variant?
     let name: String
     let format: Format
     let url: URL?
+
+    var localizedDescription: String {
+        guard let variant = variant else {
+            return name
+        }
+        return "\(name) (\(variant.name))"
+    }
+
+    init(reference: SymbolReference, variant: Variant? = nil, name: String, format: Format, url: URL? = nil) {
+        self.reference = reference
+        self.variant = variant
+        self.name = name
+        self.format = format
+        self.url = url
+    }
 
 }

--- a/Symbolic/Models/SymbolManager.swift
+++ b/Symbolic/Models/SymbolManager.swift
@@ -43,7 +43,7 @@ class SymbolManager {
         return self
             .set(for: reference)?
             .symbolsById[reference.name]?
-            .first { $0.variant == reference.variant }
+            .first { $0.variant?.id == reference.variant }
     }
 
 }

--- a/Symbolic/Resources/material-icons/manifest.json
+++ b/Symbolic/Resources/material-icons/manifest.json
@@ -3,6 +3,23 @@
     "name": "Material Icons",
     "author": "Google",
     "license": "LICENSE",
+    "variants": {
+        "default": {
+            "name": "Default"
+        },
+        "outlined": {
+            "name": "Outlined"
+        },
+        "twotone": {
+            "name": "Two Tone"
+        },
+        "round": {
+            "name": "Round"
+        },
+        "sharp": {
+            "name": "Sharp"
+        }
+    },
     "symbols": [
         {
             "id": "agriculture",

--- a/Symbolic/Views/SymbolPicker.swift
+++ b/Symbolic/Views/SymbolPicker.swift
@@ -79,7 +79,7 @@ struct SymbolPicker: View {
                                                 isPresented = false
                                                 selection.wrappedValue = symbol.reference
                                             }
-                                            .help(symbol.name)
+                                            .help(symbol.localizedDescription)
                                     }
                                 } header: {
                                     Text(section.name)

--- a/scripts/import-material-design-icons.py
+++ b/scripts/import-material-design-icons.py
@@ -17,12 +17,30 @@ def main():
     parser.add_argument("repository")
     options = parser.parse_args()
 
-    manifest = {}
-    manifest["id"] = "material-icons"
-    manifest["name"] = "Material Icons"
-    manifest["author"] = "Google"
-    manifest["license"] = "LICENSE"
-    manifest["symbols"] = []
+    manifest = {
+        "id": "material-icons",
+        "name": "Material Icons",
+        "author": "Google",
+        "license": "LICENSE",
+        "variants": {
+            "default": {
+                "name": "Default",
+            },
+            "outlined": {
+                "name": "Outlined"
+            },
+            "twotone": {
+                "name": "Two Tone",
+            },
+            "round": {
+                "name": "Round",
+            },
+            "sharp": {
+                "name": "Sharp",
+            },
+        },
+        "symbols": [],
+    }
 
     repository_directory = os.path.abspath(options.repository)
     license_path = os.path.join(repository_directory, "LICENSE")
@@ -34,6 +52,7 @@ def main():
         category_path = os.path.join(src_directory, category)
         icons = os.listdir(category_path)
         for icon in icons:
+            print("Importing '%s'..." % icon)
             symbol = {
                 "id": icon,
                 "name": icon.replace("_", " ").title(),
@@ -47,6 +66,8 @@ def main():
                 assert variant.startswith("materialicons")
                 variant_name = variant[len("materialicons"):]
                 variant_key = variant_name if variant_name else "default"
+                if variant_key not in manifest["variants"]:
+                    exit("Variant '%s' not defined in manfiest." % variant_key)
                 icon_path = os.path.join(category_path, icon, variant, "24px.svg")
                 basename = "%s.%s.svg" % (icon, variant_key)
                 shutil.copyfile(icon_path, os.path.join(MATERIAL_ICONS_DIRECTORY, basename))


### PR DESCRIPTION
This change updates the manifest format to add variant details and adds some documentation about generating symbol sets. It also includes some preparatory work for symbols that represent composed variants.