### PR TITLE
fix: Show clearer errors when failing to load documents

### DIFF
--- a/Symbolic/Models/Icon.swift
+++ b/Symbolic/Models/Icon.swift
@@ -80,7 +80,7 @@ struct Icon: Identifiable, Codable {
             self.shadowOpacity = try container.decode(CGFloat.self, forKey: .shadowOpacity)
             self.shadowHeight = try container.decode(CGFloat.self, forKey: .shadowHeight)
         default:
-            throw SymbolicError.unknownVersion
+            throw SymbolicError.unsupportedVersion
         }
 
     }

--- a/Symbolic/Models/SymbolicError.swift
+++ b/Symbolic/Models/SymbolicError.swift
@@ -26,7 +26,7 @@ enum SymbolicError: Error {
     case exportFailure
     case missingManifest
     case missingLicense
-    case unknownVersion
+    case unsupportedVersion
 
 }
 
@@ -46,8 +46,8 @@ extension SymbolicError: LocalizedError {
             return "Missing library manifest."
         case .missingLicense:
             return "Missing library license."
-        case .unknownVersion:
-            return "Unknown version."
+        case .unsupportedVersion:
+            return "Unsupported version."
         }
     }
 
@@ -61,7 +61,7 @@ extension SymbolicError: LocalizedError {
             return nil
         case .missingLicense:
             return nil
-        case .unknownVersion:
+        case .unsupportedVersion:
             return "Document was created with a later version of Symbolic. Update Symbolic to view and edit this document."
         }
     }

--- a/Symbolic/Models/SymbolicError.swift
+++ b/Symbolic/Models/SymbolicError.swift
@@ -29,3 +29,41 @@ enum SymbolicError: Error {
     case unknownVersion
 
 }
+
+extension SymbolicError: LocalizedError {
+
+    var errorDescription: String? {
+        return nil
+    }
+
+    var failureReason: String? {
+        switch self {
+        case .invalidColorspace:
+            return "Invalid colorspace."
+        case .exportFailure:
+            return "Export failure."
+        case .missingManifest:
+            return "Missing library manifest."
+        case .missingLicense:
+            return "Missing library license."
+        case .unknownVersion:
+            return "Unknown version."
+        }
+    }
+
+    var recoverySuggestion: String? {
+        switch self {
+        case .invalidColorspace:
+            return nil
+        case .exportFailure:
+            return nil
+        case .missingManifest:
+            return nil
+        case .missingLicense:
+            return nil
+        case .unknownVersion:
+            return "Document was created with a later version of Symbolic. Update Symbolic to view and edit this document."
+        }
+    }
+
+}

--- a/SymbolicTests/FileTests.swift
+++ b/SymbolicTests/FileTests.swift
@@ -60,7 +60,7 @@ final class FileTests: XCTestCase {
 
         let data = try Data(contentsOf: url)
         XCTAssertThrowsError(try JSONDecoder().decode(Icon.self, from: data)) { error in
-            XCTAssertEqual(error as? SymbolicError, SymbolicError.unknownVersion)
+            XCTAssertEqual(error as? SymbolicError, SymbolicError.unsupportedVersion)
         }
     }
 


### PR DESCRIPTION
This change adds a failure reason and recovery suggestion to `SymbolicError` to ensure errors are more helpful to users.

<img width="372" alt="Screenshot 2023-01-23 at 09 43 54" src="https://user-images.githubusercontent.com/220887/214014108-08a06c2a-7794-4350-82ec-8b6d1d71374c.png">
