### PR TITLE
fix: 📐 Consistent symbol positioning across previews and exports

### DIFF
--- a/Symbolic/Extensions/View.swift
+++ b/Symbolic/Extensions/View.swift
@@ -22,22 +22,12 @@ import SwiftUI
 
 extension View {
 
-    func snapshot() -> Data? {
-        let controller = NSHostingController(rootView: self)
-        let targetSize = controller.view.intrinsicContentSize
-        let contentRect = NSRect(origin: .zero, size: targetSize)
-        let window = UnityScaleWindow(contentRect: contentRect,
-                                      styleMask: [.borderless],
-                                      backing: .buffered,
-                                      defer: false)
-        window.contentView = controller.view
-        guard let bitmapRep = controller.view.bitmapImageRepForCachingDisplay(in: contentRect) else {
+    @MainActor func pngData() -> Data? {
+        let renderer = ImageRenderer(content: self)
+        renderer.scale = 2
+        guard let image = renderer.nsImage else {
             return nil
         }
-        controller.view.cacheDisplay(in: contentRect, to: bitmapRep)
-        let image = NSImage(size: bitmapRep.size)
-        image.addRepresentation(bitmapRep)
-
         guard let tiffRepresentation = image.tiffRepresentation else {
             return nil
         }

--- a/Symbolic/Models/IconDocument.swift
+++ b/Symbolic/Models/IconDocument.swift
@@ -69,23 +69,7 @@ final class IconDocument: ReferenceFileDocument {
                 let directoryUrl = url.appendingPathComponent(section.directory, conformingTo: .directory)
                 try FileManager.default.createDirectory(at: directoryUrl, withIntermediateDirectories: true)
                 for definition in iconSet.definitions {
-                    switch definition.style {
-                    case .macOS:
-                        try icon.saveMacSnapshot(size: definition.size.width,
-                                                 scale: definition.scale,
-                                                 directoryURL: directoryUrl)
-                    case .iOS:
-                        try icon.saveSnapshot(size: definition.size.width,
-                                              scale: definition.scale,
-                                              shadow: false,
-                                              directoryURL: directoryUrl)
-                    case .watchOS:
-                        try icon.saveSnapshot(size: definition.size.width,
-                                              scale: definition.scale,
-                                              shadow: false,
-                                              isWatchOS: true,
-                                              directoryURL: directoryUrl)
-                    }
+                    try icon.saveSnapshot(definition: definition, directoryURL: directoryUrl)
                 }
             }
         }

--- a/Symbolic/Toolbars/ExportToolbar.swift
+++ b/Symbolic/Toolbars/ExportToolbar.swift
@@ -20,51 +20,6 @@
 
 import SwiftUI
 
-extension Icon {
-
-    @MainActor func saveMacSnapshot(size: CGFloat,
-                                    scale: Int = 1,
-                                    shadow: Bool = true,
-                                    directoryURL: URL) throws {
-        let scaledSize = size * CGFloat(scale)
-        let icon = MacIconView(icon: self, size: scaledSize, isShadowFlipped: true)
-        guard let data = icon.snapshot() else {
-            throw SymbolicError.exportFailure
-        }
-        let formatter = NumberFormatter()
-        formatter.minimumFractionDigits = 0
-        formatter.maximumFractionDigits = 2
-        guard let sizeString = formatter.string(from: NSNumber(value: size)) else {
-            throw SymbolicError.exportFailure
-        }
-        let scaleString = scale > 1 ? String(format: "@%dx", scale) : ""
-        let url = directoryURL.appendingPathComponent("icon_\(sizeString)x\(sizeString)\(scaleString)", conformingTo: .png)
-        try data.write(to: url)
-    }
-
-    @MainActor func saveSnapshot(size: CGFloat,
-                                 scale: Int = 1,
-                                 shadow: Bool = true,
-                                 isWatchOS: Bool = false,
-                                 directoryURL: URL) throws {
-        let scaledSize = size * CGFloat(scale)
-        let icon = IconView(icon: self, size: scaledSize, renderShadow: shadow, isShadowFlipped: true, isWatchOS: isWatchOS)
-        guard let data = icon.snapshot() else {
-            throw SymbolicError.exportFailure
-        }
-        let formatter = NumberFormatter()
-        formatter.minimumFractionDigits = 0
-        formatter.maximumFractionDigits = 2
-        guard let sizeString = formatter.string(from: NSNumber(value: size)) else {
-            throw SymbolicError.exportFailure
-        }
-        let scaleString = scale > 1 ? String(format: "@%dx", scale) : ""
-        let url = directoryURL.appendingPathComponent("icon_\(sizeString)x\(sizeString)\(scaleString)", conformingTo: .png)
-        try data.write(to: url)
-    }
-
-}
-
 struct ExportToolbar: CustomizableToolbarContent {
 
     @FocusedObject private var sceneModel: SceneModel?

--- a/Symbolic/Views/IconPreview.swift
+++ b/Symbolic/Views/IconPreview.swift
@@ -33,26 +33,19 @@ struct IconPreview: View {
             let width = definition.size.width * (CGFloat(definition.scale) / 2)
             let height = definition.size.height * (CGFloat(definition.scale) / 2)
 
-            switch definition.style {
-            case .macOS:
-                MacIconView(icon: icon, size: width, isShadowFlipped: false)
-                if sceneModel.showGrid {
+            icon.view(for: definition)
+
+            if sceneModel.showGrid {
+                switch definition.style {
+                case .macOS:
                     Image("Grid_macOS")
                         .resizable()
                         .frame(width: width, height: height)
-                }
-            case .iOS:
-                IconView(icon: icon, size: width, renderShadow: false)
-                    .modifier(IconCorners(size: width, style: .iOS))
-                if sceneModel.showGrid {
+                case .iOS:
                     Image("Grid_iOS")
                         .resizable()
                         .frame(width: width, height: height)
-                }
-            case .watchOS:
-                IconView(icon: icon, size: width, renderShadow: false, isWatchOS: true)
-                    .modifier(IconCorners(size: width, style: .watchOS))
-                if sceneModel.showGrid {
+                case .watchOS:
                     WatchGridView(size: width)
                 }
             }

--- a/Symbolic/Views/IconView.swift
+++ b/Symbolic/Views/IconView.swift
@@ -29,7 +29,6 @@ struct IconView: View {
     var icon: Icon
     var size: CGFloat
     var renderShadow: Bool = true
-    var isShadowFlipped = false
     var isWatchOS = false
 
     var iconSize: CGFloat {
@@ -50,7 +49,7 @@ struct IconView: View {
             let x = size / 2
             let y = size / 2
             let shadowRadius = size * icon.shadowHeight * Constants.shadowOffsetScaleFactor
-            let shadowOffset = size * icon.shadowHeight * Constants.shadowOffsetScaleFactor * (isShadowFlipped ? -1.0 : 1.0)
+            let shadowOffset = size * icon.shadowHeight * Constants.shadowOffsetScaleFactor
 
             LinearGradient(gradient: Gradient(colors: [icon.topColor, icon.bottomColor]),
                            startPoint: .top,

--- a/Symbolic/Views/MacIconView.swift
+++ b/Symbolic/Views/MacIconView.swift
@@ -24,15 +24,14 @@ struct MacIconView: View {
 
     var icon: Icon
     var size: CGFloat
-    var isShadowFlipped: Bool
 
     var body: some View {
         HStack {
-            IconView(icon: icon, size: size * 0.8046875, isShadowFlipped: isShadowFlipped)
+            IconView(icon: icon, size: size * 0.8046875)
                 .modifier(IconCorners(size: size * 0.8046875, style: .macOS))
                 .shadow(color: .black.opacity(0.3),
                         radius: size * 0.0068359375,
-                        y: size * 0.009765625 * (isShadowFlipped ? -1.0 : 1.0))
+                        y: size * 0.009765625)
         }
         .frame(width: size, height: size)
     }


### PR DESCRIPTION
For some reason the AppKit-based SwiftUI exporting positions the SF Symbols based views slightly differently with some symbols. This change switches to using the ‘new’ built-in `ImageRenderer` to export icons.

It also includes some drive-by consolidation of export methods.