### PR TITLE
fix: Re-enable GitHub about screen links

### DIFF
--- a/Symbolic/Models/ApplicationModel.swift
+++ b/Symbolic/Models/ApplicationModel.swift
@@ -158,13 +158,14 @@ class ApplicationModel: ObservableObject {
 
         let title = "Symbolic Support (\(Bundle.main.version ?? "Unknown Version"))"
 
-        return NSWindow(copyright: "Copyright © 2022-2024 Jason Morley") {
+        return NSWindow(repository: "inseven/symbolic",
+                        copyright: "Copyright © 2022-2024 Jason Morley") {
             Action("Website", url: URL(string: "https://symbolic.app")!)
             Action("Privacy", url: URL(string: "https://symbolic.app/privacy-policy")!)
             Action("Support", url: URL(address: "support@symbolic.app", subject: title)!)
         } acknowledgements: {
             Acknowledgements("Developers") {
-                Credit("Jason Morley", url: URL(string: "https://jbmorley.co.uk"))
+                Credit("Jason Morley", url: URL(string: "https://jbmorley.co.uk/about"))
             }
             Acknowledgements("Thanks") {
                 Credit("Lukas Fittl")


### PR DESCRIPTION
This change also includes a drive-by update to link to https://jbmorley.co.uk/about.