### PR TITLE
fix: Exports fail when replacing existing files

### DIFF
--- a/Symbolic/Models/SceneModel.swift
+++ b/Symbolic/Models/SceneModel.swift
@@ -91,6 +91,10 @@ class SceneModel: ObservableObject, Runnable {
 
     @MainActor func export(destination url: URL) {
         do {
+            let fileManager = FileManager.default
+            if fileManager.fileExists(atPath: url.path) {
+                try fileManager.removeItem(at: url)
+            }
             try document.export(destination: url)
             NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: url.absoluteString)
         } catch {


### PR DESCRIPTION
The macOS save panel allows users to select and replace existing files but we still need to perform the deletion ourselves.