### PR TITLE
ci: Website builds should depend on app builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,6 +53,8 @@ jobs:
 
   website-build:
 
+    needs: app-build
+
     runs-on: ubuntu-latest
 
     steps:
@@ -86,20 +88,17 @@ jobs:
     needs: website-build
     if: ${{ github.ref == 'refs/heads/main' }}
 
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
+      pages: write
+      id-token: write
 
-    # Deploy to the github-pages environment
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    # Specify runner + deployment step
     runs-on: ubuntu-latest
 
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4 # or the latest "vX.X.X" version tag for this action
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
We want to make sure the website build is performed after any releases.