### PR TITLE
fix: ⬆️ Update the ‘Export’ menu item icon

### DIFF
--- a/Symbolic/Commands/ExportCommands.swift
+++ b/Symbolic/Commands/ExportCommands.swift
@@ -34,7 +34,7 @@ struct ExportCommands: Commands {
             Button {
                 sceneModel?.export()
             } label: {
-                Label("Export...", systemImage: "arrow.down.document")
+                Label("Export...", systemImage: "arrow.up")
             }
             .disabled(sceneModel == nil)
             .keyboardShortcut("e")


### PR DESCRIPTION
This brings it-line with the toolbar button.