### PR TITLE
fix: ✍️ Improve appearance of SF Symbols at smaller sizes

### DIFF
--- a/apple/SymbolicCore/Sources/SymbolicCore/Views/IconView.swift
+++ b/apple/SymbolicCore/Sources/SymbolicCore/Views/IconView.swift
@@ -39,6 +39,19 @@ struct IconView: View {
         }
     }
 
+    var symbolWeight: Font.Weight {
+        switch iconSize * 2 {
+        case ..<24:
+            return .black
+        case ..<48:
+            return .bold
+        case ..<96:
+            return .semibold
+        default:
+            return .regular
+        }
+    }
+
     var iconOffset: CGSize {
         return CGSize(width: icon.iconOffset.width * size,
                       height: icon.iconOffset.height * size * -1.0)
@@ -55,7 +68,7 @@ struct IconView: View {
                            startPoint: .top,
                            endPoint: .bottom)
 
-            let image = SymbolView(symbolReference: icon.symbol)
+            let image = SymbolView(symbolReference: icon.symbol, weight: symbolWeight)
                 .foregroundColor(icon.symbolColor)
 
             VStack {

--- a/apple/SymbolicCore/Sources/SymbolicCore/Views/SymbolView.swift
+++ b/apple/SymbolicCore/Sources/SymbolicCore/Views/SymbolView.swift
@@ -23,9 +23,11 @@ import SwiftUI
 public struct SymbolView: View {
 
     public let symbolReference: SymbolReference
+    public let weight: Font.Weight
 
-    public init(symbolReference: SymbolReference) {
+    public init(symbolReference: SymbolReference, weight: Font.Weight = .regular) {
         self.symbolReference = symbolReference
+        self.weight = weight
     }
 
     public var body: some View {
@@ -38,6 +40,7 @@ public struct SymbolView: View {
                     Image(systemName: symbol.name)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
+                        .fontWeight(weight)
                         .symbolRenderingMode(renderingMode.symbolRenderingMode)
                         .environment(\.colorScheme, .light)  // Ensure symbols display consistently in light and dark modes.
                 }


### PR DESCRIPTION
This change dynamically selects SF Symbol weights based on their size to improve the appearance in smaller sizes.
