### PR TITLE
ci: 🔨 Update build-tools

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -184,7 +184,8 @@ xcodebuild \
 build-tools notarize "$BUILD_DIRECTORY/Symbolic.app" \
     --key "$API_KEY_PATH" \
     --key-id "$APPLE_API_KEY_ID" \
-    --issuer "$APPLE_API_KEY_ISSUER_ID"
+    --issuer "$APPLE_API_KEY_ISSUER_ID" \
+    --log-directory "$BUILD_DIRECTORY"
 
 # Compress the app.
 APP_BASENAME="Symbolic.app"


### PR DESCRIPTION
This change catches up to the latest build tools and adopts the new `notarize` `--log-directory` parameter.

scripts/build-tools:

- 7a52a62 fix: ⌨️ Support subcommand autocomplete (jbmorley/build-tools#26)
- 3418335 feat!: 🧨 Update version to 1.0.0 (jbmorley/build-tools#24)
- f65f70c feat! 🧨 Update version to 1.0.0 (jbmorley/build-tools#23)
- 07d918f fix: 🏃 Adopt `fastcommand` for command handling (jbmorley/build-tools#22)
- 148c303 fix: 🔐 Respect the provided password when creating a new keychain (jbmorley/build-tools#21)
- ba11843 fix: 📝 Add a PyPI summary description (jbmorley/build-tools#20)
- 3564f41 feat: 🚀 Publish to PyPI (jbmorley/build-tools#18)
- c13fe37 feat: 🏃 Notarize multiple bundles and binaries concurrently (jbmorley/build-tools#17)
- 731993e fix: Update the artifact manifest format to support multiple targets (jbmorley/build-tools#15)
- 7289610 feat: Add `add-artifact` subcommand for managing artifact manifest files (jbmorley/build-tools#14)
- 64c7475 fix: Add an option to `notarize` to skip stapling (jbmorley/build-tools#13)
- 4c3cd2f fix: Address `datetime.utcnow` deprecation (jbmorley/build-tools#12)
- 853201e fix: Improve logging for the `notarize` command (jbmorley/build-tools#11)